### PR TITLE
specify node port

### DIFF
--- a/packages/web/core/service/apiService.ts
+++ b/packages/web/core/service/apiService.ts
@@ -1,7 +1,8 @@
 import axiosInstance  from '../axios'
 
+const node_port = new URLSearchParams(window.location.search).get('node') ?? 3001
 const api = axiosInstance({
-  baseURL: 'http://localhost:3001/api/'
+  baseURL: 'http://localhost:'+ node_port +'/api/'
 })
 
 export const apiRequest = {


### PR DESCRIPTION
default node port used in front end is 3001, but another can also be specified by attaching the url query node=<port>. Example: http://localhost:3000/?node=56827